### PR TITLE
Add semesters to class categories

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -143,7 +143,7 @@ exports.createPages = ({ actions, graphql }) => {
   });
 };
 
-exports.onCreateNode = ({ node, actions, getNode }) => {
+exports.onCreateNode = async ({ node, actions, getNode }) => {
   const { createNodeField } = actions;
   fmImagesToRelative(node); // convert image paths for gatsby images
 
@@ -154,6 +154,22 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
       node,
       value,
     });
+
+    if (!!node.frontmatter && node.frontmatter.templateKey === `experience-levels`) {
+      if (node.frontmatter.courseOfferingEndpoint) {
+        console.log(`Loading extras for`, node.frontmatter.title);
+        const classTypesEndpoint = new URL(node.frontmatter.courseOfferingEndpoint, dashboardBaseUrl);
+        const { classTypes } = await GET(classTypesEndpoint);
+        const semesters = [...new Set(classTypes.map((ct) => ct.semester))];
+        createNodeField({
+          node,
+          name: `extras`,
+          value: { semesters }
+        })
+      } else {
+        throw new Error(`Missing 'courseOfferingEndpoint' for 'experience-level' node: ${JSON.stringify(node)}`)
+      }
+    }
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
   "main": "n/a",
   "scripts": {
     "clean": "gatsby clean",
-    "start": "npm run develop",
-    "build": "npm run clean && gatsby build",
-    "develop": "npm run clean && gatsby develop",
+    "start": "yarn run develop",
+    "build": "yarn run clean && gatsby build",
+    "develop": "yarn run clean && gatsby develop",
     "format": "prettier --trailing-comma es5 --arrowParens avoid --write \"{gatsby-*.js,src/**/*.js}\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/src/components/ClassCards.scss
+++ b/src/components/ClassCards.scss
@@ -1,7 +1,7 @@
 .class-card-list {
   display: grid;
   grid-template-columns: repeat(12, 1fr);
-  display: grid;
+  grid-template-rows: min-content;
   width: 100%;
   grid-column-gap: 1rem;
   row-gap: 2rem;

--- a/src/components/CourseOfferings.js
+++ b/src/components/CourseOfferings.js
@@ -165,6 +165,18 @@ const formatResponse = (classType) => {
   };
 };
 
+const sortClassLocations = (a, b) => {
+  /* online goes last */
+  const aIsOnline = a.label.toLowerCase().includes("online");
+  const bIsOnline = b.label.toLowerCase().includes("online");
+  if (aIsOnline !== bIsOnline) {
+    if (aIsOnline) return 1;
+    if (bIsOnline) return -1;
+  }
+
+  return a.value.localeCompare(b.value);
+}
+
 const filterTemplate = [
   {
     label: "SEMESTER",
@@ -179,6 +191,7 @@ const filterTemplate = [
     optionKeys: [], // value + label off top-level object directly
     valueKeys: ["locationId"],
     labelKeys: ["locationName"],
+    sort: sortClassLocations
   },
   {
     label: "SIGNUP TYPE",

--- a/src/components/CourseOfferings.scss
+++ b/src/components/CourseOfferings.scss
@@ -32,6 +32,7 @@
           label {
             font-weight: normal;
             font-family: var(--fontStack);
+            cursor: pointer;
           }
         }
       }

--- a/src/hooks/useFilters.js
+++ b/src/hooks/useFilters.js
@@ -73,18 +73,8 @@ const buildOptions = (collection, filter) => {
     }
   }
 
-  if (filter.filterKey === "class_location_ids") {
-    return options.sort((a, b) => {
-      /* online goes last */
-      const aIsOnline = a.label.toLowerCase().includes("online");
-      const bIsOnline = b.label.toLowerCase().includes("online");
-      if (aIsOnline !== bIsOnline) {
-        if (aIsOnline) return 1;
-        if (bIsOnline) return -1;
-      }
-
-      return a.value.localeCompare(b.value);
-    })
+  if (!!filter.sort) {
+    return options.sort(filter.sort)
   } else {
     return options.sort((a, b) => a.value.localeCompare(b.value));
   }

--- a/src/pages/classes.js
+++ b/src/pages/classes.js
@@ -12,7 +12,37 @@ import ClassCards from "../components/ClassCards";
 
 import "./classes.scss";
 
+const seasonScore = {
+  Spring: 1,
+  Summer: 2,
+  Fall: 3
+}
+
+const sortSemester = (a, b) => {
+  const [aSeason, aYear] = a.value.split(" ");
+  const [bSeason, bYear] = b.value.split(" ");
+
+  if (aYear > bYear) return 1;
+  if (aYear < bYear) return -1;
+
+  const aSeasonScore = seasonScore[aSeason] || 4;
+  const bSeasonScore = seasonScore[bSeason] || 4;
+
+  if (aSeasonScore > bSeasonScore) return 1;
+  if (aSeasonScore < bSeasonScore) return -1;
+
+  return 0
+
+}
+
 const filterTemplate = [
+  {
+    label: "SEMESTER",
+    filterKey: "semesters",
+    type: "checkbox",
+    optionValueKeys: ["extras", "semesters"],
+    sort: sortSemester
+},
   {
     label: "EXPERIENCE",
     filterKey: "experiences",
@@ -104,8 +134,8 @@ const ClassesPage = ({ data }) => {
   const experienceLevels = data.experienceLevelQuery.experienceLevels?.map(
     levelNode => {
       return {
-        ...levelNode.frontmatter,
-        slug: levelNode.fields.slug,
+        ...levelNode.frontmatter, // most MD file things
+        ...levelNode.fields // slug, extras
       };
     }
   );
@@ -163,6 +193,9 @@ export const pageQuery = graphql`
         }
         fields {
           slug
+          extras {
+            semesters
+          }
         }
       }
     }

--- a/src/pages/classes.js
+++ b/src/pages/classes.js
@@ -37,17 +37,17 @@ const sortSemester = (a, b) => {
 
 const filterTemplate = [
   {
+    label: "EXPERIENCE",
+    filterKey: "experiences",
+    type: "checkbox",
+    optionValueKeys: ["details", "experience"],
+  },
+  {
     label: "SEMESTER",
     filterKey: "semesters",
     type: "checkbox",
     optionValueKeys: ["extras", "semesters"],
     sort: sortSemester
-},
-  {
-    label: "EXPERIENCE",
-    filterKey: "experiences",
-    type: "checkbox",
-    optionValueKeys: ["details", "experience"],
   },
   {
     label: "GENDER",

--- a/src/pages/classes.js
+++ b/src/pages/classes.js
@@ -17,28 +17,24 @@ const filterTemplate = [
     label: "EXPERIENCE",
     filterKey: "experiences",
     type: "checkbox",
-    initialValue: [],
     optionValueKeys: ["details", "experience"],
   },
   {
     label: "GENDER",
     filterKey: "genders",
     type: "checkbox",
-    initialValue: [],
     optionValueKeys: ["details", "gender"],
   },
   {
     label: "SKILLS",
     filterKey: "skills",
     type: "checkbox",
-    initialValue: [],
     optionValueKeys: ["details", "skills"],
   },
   {
     label: "LOOKING FOR",
     filterKey: "sellingPoints",
     type: "checkbox",
-    initialValue: [],
     optionValueKeys: ["details", "sellingPoints"],
   },
 ];

--- a/src/pages/classes.scss
+++ b/src/pages/classes.scss
@@ -52,6 +52,7 @@
           label {
             font-weight: normal;
             font-family: var(--fontStack);
+            cursor: pointer;
           }
         }
       }


### PR DESCRIPTION
What does it do?

This adds an 'extras' field to the class category page analog (experience-type) by pulling a fresh list of classes from dashboard at build time

We're chosing to _not_ use this for the 'live' class inventory on the page as that updates quite frequently and we always want info to be as up to date as possible. Semesters, though, are pretty static.

What does it looks like?

<img width="1267" alt="Screen Shot 2021-06-07 at 12 42 27 PM" src="https://user-images.githubusercontent.com/15863213/121071958-d9017680-c78d-11eb-99e8-061f0ab8384d.png">

What's up with this sorting?

<img width="165" alt="Screen Shot 2021-06-07 at 12 06 53 PM" src="https://user-images.githubusercontent.com/15863213/121071894-c4bd7980-c78d-11eb-915d-55e810a113ef.png">
