### PR TITLE
Img size improvements

### DIFF
--- a/src/components/ClassCards.js
+++ b/src/components/ClassCards.js
@@ -39,7 +39,7 @@ const ClassCards = ({ activeLevels, slugExtension = "" }) => {
                     imageInfo={{
                       image: thumbnail,
                       alt: title,
-                      imageStyle: { width: "100%", height: "auto" },
+                      imageStyle: { width: "100%", height: "200px" },
                     }}
                   />
                 </div>

--- a/src/components/ClassCards.scss
+++ b/src/components/ClassCards.scss
@@ -21,7 +21,7 @@
       grid-template-rows: repeat(3, max-content) 1fr max-content;
       border: 1px solid currentColor;
       border-radius: 2px;
-      background-color: var(--background);
+      background-color: var(--backgroundAlt);
       transition: box-shadow 200ms ease, transform 200ms ease;
       box-shadow: 0px 0px 0 currentColor;
 
@@ -66,7 +66,7 @@
       &__byline {
         font-size: 0.875rem;
         margin: 0 0 0.5rem;
-        height:  30px;
+        min-height:  30px;
       }
 
       &__img {

--- a/src/components/ClassCards.scss
+++ b/src/components/ClassCards.scss
@@ -1,4 +1,5 @@
 .class-card-list {
+  color: var(--primary);
   display: grid;
   grid-template-columns: repeat(12, 1fr);
   grid-template-rows: min-content;
@@ -20,7 +21,7 @@
       grid-template-rows: repeat(3, max-content) 1fr max-content;
       border: 1px solid currentColor;
       border-radius: 2px;
-      background-color: var(--backgroundAlt);
+      background-color: var(--background);
       transition: box-shadow 200ms ease, transform 200ms ease;
       box-shadow: 0px 0px 0 currentColor;
 

--- a/src/components/ClassCards.scss
+++ b/src/components/ClassCards.scss
@@ -15,7 +15,7 @@
     .class-card {
       padding: 1rem;
       display: grid;
-      min-height: 24.5rem;
+      min-height: 25rem;
       position: relative;
       grid-template-rows: repeat(3, max-content) 1fr max-content;
       border: 1px solid currentColor;
@@ -65,11 +65,12 @@
       &__byline {
         font-size: 0.875rem;
         margin: 0 0 0.5rem;
+        height:  30px;
       }
 
       &__img {
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         justify-content: center;
         padding-bottom: 0.875rem;
       }
@@ -92,8 +93,8 @@
       grid-column-end: span 6;
     }
 
-    // Medium devices (tablets, 768px and up)
-    @media (min-width: 768px) {
+    // Medium devices (large tablets, computers and up)
+    @media (min-width: 992px) {
       grid-column-end: span 4;
     }
   }

--- a/src/components/all.scss
+++ b/src/components/all.scss
@@ -9,6 +9,7 @@
   --primary-rgb: 39, 69, 72;
   --text-primary: var(--primary);
   --text-accent: var(--accent);
+  --text-alt: var(--white);
   --primary-btn: #edc034;
   --disabled: #dfd1a7;
   --hr: rgba(0, 0, 0, 0.2);

--- a/src/components/all.scss
+++ b/src/components/all.scss
@@ -154,9 +154,6 @@ sub {
 sup {
   top: -0.5em;
 }
-img {
-  border-style: none;
-}
 svg:not(:root) {
   overflow: hidden;
 }
@@ -444,7 +441,8 @@ button--disabled .button--isSubmitting,
 }
 img {
   border-radius: 0;
-  width: 100%;
+  border-style: none;
+  max-width: 100%;
 }
 
 .btn {

--- a/src/hooks/useFilters.js
+++ b/src/hooks/useFilters.js
@@ -53,7 +53,6 @@ const buildOptions = (collection, filter) => {
       if (Array.isArray(rawNestedItem)) {
         for (let nestedItem of rawNestedItem) {
           const value = dig(nestedItem, filter.valueKeys);
-          console.log(value);
 
           if (!!value && !options.some((opt) => opt.value === value)) {
             const label = dig(nestedItem, filter.labelKeys);

--- a/src/pages/classes.js
+++ b/src/pages/classes.js
@@ -183,8 +183,8 @@ export const pageQuery = graphql`
           }
           thumbnail {
             childImageSharp {
-              fluid(maxWidth: 480, quality: 80) {
-                ...GatsbyImageSharpFluid
+              fixed(height: 200, quality: 80) {
+                ...GatsbyImageSharpFixed
               }
             }
             extension

--- a/src/templates/styles/locations.scss
+++ b/src/templates/styles/locations.scss
@@ -59,7 +59,7 @@
       display: flex;
       flex-flow: row wrap;
       margin: 0;
-      padding-bottom: .5rem;
+      padding: 0 0 .5rem 0;
       justify-content: center;
 
       &__item {

--- a/src/templates/styles/locations.scss
+++ b/src/templates/styles/locations.scss
@@ -59,7 +59,7 @@
       display: flex;
       flex-flow: row wrap;
       margin: 0;
-      padding: 0;
+      padding-bottom: .5rem;
       justify-content: center;
 
       &__item {

--- a/src/templates/styles/locations.scss
+++ b/src/templates/styles/locations.scss
@@ -43,10 +43,12 @@
   padding: 1.5rem;
   display: grid;
   grid-template-columns: 1fr;
+  background-color: var(--primary);
+  color: var(--text-alt);
 
   &__header {
     text-align: center;
-    border-bottom: 1px solid var(--hr);
+    border-bottom: 4px solid var(--accent);
 
     &__title {
       margin: 0.5rem;
@@ -68,6 +70,7 @@
           padding: 0.25rem 0.85rem;
           margin: 4px;
           border-bottom: 4px solid currentColor;
+          color: var(--text-alt);
         }
 
         &--active {


### PR DESCRIPTION
![Screen Shot 2021-06-07 at 13 58 02 PM](https://user-images.githubusercontent.com/30125327/121080242-6f3a9a00-c798-11eb-808f-2d7991a51535.png)

Standard image heights for a more consistent look on our class cards. 

Eventually, we might want to look at gatsby-plugin-image (their newer more full-featured image handling plugin). Only went along with what the starter had. 