### PR TITLE
Simple Location pages

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -74,10 +74,11 @@ exports.sourceNodes = async ({
   }
 };
 
-exports.createPages = ({ actions, graphql }) => {
+exports.createPages = async ({ actions, graphql }) => {
   const { createPage } = actions;
 
-  return graphql(`
+  // add pages for all MD files
+  await graphql(`
     {
       allMarkdownRemark(limit: 1000) {
         edges {
@@ -137,6 +138,38 @@ exports.createPages = ({ actions, graphql }) => {
         component: path.resolve(`src/templates/tags.js`),
         context: {
           tag,
+        },
+      });
+    });
+  });
+
+  // add pages for all classLocations
+  await graphql(`
+    {
+      allClassLocation {
+        nodes {
+          classLocationId
+          code
+        }
+      }
+    }
+  `).then((result) => {
+    if (result.errors) {
+      result.errors.forEach((e) => console.error(e.toString()));
+      return Promise.reject(result.errors);
+    }
+
+    const locations = result.data.allClassLocation.nodes;
+
+    locations.forEach((node) => {
+      const { classLocationId, code } = node;
+      createPage({
+        path: `/locations/${code}`,
+        component: path.resolve(`src/templates/location.js`),
+        // additional data can be passed via context
+        context: {
+          classLocationId,
+          code
         },
       });
     });

--- a/src/components/ClassPanel.js
+++ b/src/components/ClassPanel.js
@@ -1,0 +1,95 @@
+import * as React from "react";
+import { isMobile } from "../utils/helpers";
+
+import { useFilters } from "../hooks";
+import FilterForm from "./FilterForm";
+
+import ClassCards from "./ClassCards";
+
+import "./ClassPanel.scss";
+
+const seasonScore = {
+  Spring: 1,
+  Summer: 2,
+  Fall: 3
+}
+
+const sortSemester = (a, b) => {
+  const [aSeason, aYear] = a.value.split(" ");
+  const [bSeason, bYear] = b.value.split(" ");
+
+  if (aYear > bYear) return 1;
+  if (aYear < bYear) return -1;
+
+  const aSeasonScore = seasonScore[aSeason] || 4;
+  const bSeasonScore = seasonScore[bSeason] || 4;
+
+  if (aSeasonScore > bSeasonScore) return 1;
+  if (aSeasonScore < bSeasonScore) return -1;
+
+  return 0
+
+}
+
+const filterTemplate = [
+  {
+    label: "SEMESTER",
+    filterKey: "semesters",
+    type: "checkbox",
+    optionValueKeys: ["extras", "semesters"],
+    sort: sortSemester
+  },
+  {
+    label: "EXPERIENCE",
+    filterKey: "experiences",
+    type: "checkbox",
+    optionValueKeys: ["details", "experience"],
+  },
+  {
+    label: "GENDER",
+    filterKey: "genders",
+    type: "checkbox",
+    optionValueKeys: ["details", "gender"],
+  },
+  {
+    label: "SKILLS",
+    filterKey: "skills",
+    type: "checkbox",
+    optionValueKeys: ["details", "skills"],
+  },
+  {
+    label: "LOOKING FOR",
+    filterKey: "sellingPoints",
+    type: "checkbox",
+    optionValueKeys: ["details", "sellingPoints"],
+  },
+];
+
+const ClassPanel = ({ experienceLevels }) => {
+  const [filters, activeFilter, activeLevels] = useFilters(
+    filterTemplate,
+    experienceLevels
+  );
+
+  return (
+    <div className="ClassPanel">
+      {!!isMobile() ? (
+        <details className="custom-details-tag">
+          <summary>Filter By </summary>
+          <FilterForm
+            activeFilter={activeFilter}
+            filters={filters}
+          />
+        </details>
+      ) : (
+        <FilterForm
+          activeFilter={activeFilter}
+          filters={filters}
+        />
+      )}
+      <ClassCards activeLevels={activeLevels} />
+    </div>
+  );
+};
+
+export default ClassPanel;

--- a/src/components/ClassPanel.js
+++ b/src/components/ClassPanel.js
@@ -65,7 +65,7 @@ const filterTemplate = [
   },
 ];
 
-const ClassPanel = ({ experienceLevels }) => {
+const ClassPanel = ({ experienceLevels, slugExtension }) => {
   const [filters, activeFilter, activeLevels] = useFilters(
     filterTemplate,
     experienceLevels
@@ -87,7 +87,7 @@ const ClassPanel = ({ experienceLevels }) => {
           filters={filters}
         />
       )}
-      <ClassCards activeLevels={activeLevels} />
+      <ClassCards activeLevels={activeLevels} slugExtension={slugExtension} />
     </div>
   );
 };

--- a/src/components/ClassPanel.js
+++ b/src/components/ClassPanel.js
@@ -11,8 +11,8 @@ import "./ClassPanel.scss";
 const seasonScore = {
   Spring: 1,
   Summer: 2,
-  Fall: 3
-}
+  Fall: 3,
+};
 
 const sortSemester = (a, b) => {
   const [aSeason, aYear] = a.value.split(" ");
@@ -27,9 +27,8 @@ const sortSemester = (a, b) => {
   if (aSeasonScore > bSeasonScore) return 1;
   if (aSeasonScore < bSeasonScore) return -1;
 
-  return 0
-
-}
+  return 0;
+};
 
 const filterTemplate = [
   {
@@ -37,7 +36,7 @@ const filterTemplate = [
     filterKey: "semesters",
     type: "checkbox",
     optionValueKeys: ["extras", "semesters"],
-    sort: sortSemester
+    sort: sortSemester,
   },
   {
     label: "EXPERIENCE",
@@ -65,7 +64,7 @@ const filterTemplate = [
   },
 ];
 
-const ClassPanel = ({ experienceLevels, slugExtension }) => {
+const ClassPanel = ({ title, experienceLevels, slugExtension }) => {
   const [filters, activeFilter, activeLevels] = useFilters(
     filterTemplate,
     experienceLevels
@@ -73,19 +72,18 @@ const ClassPanel = ({ experienceLevels, slugExtension }) => {
 
   return (
     <div className="ClassPanel">
+      {!!title && (
+        <div className="ClassPanel__title">
+          <h2>{title}</h2>
+        </div>
+      )}
       {!!isMobile() ? (
         <details className="custom-details-tag">
           <summary>Filter By </summary>
-          <FilterForm
-            activeFilter={activeFilter}
-            filters={filters}
-          />
+          <FilterForm activeFilter={activeFilter} filters={filters} />
         </details>
       ) : (
-        <FilterForm
-          activeFilter={activeFilter}
-          filters={filters}
-        />
+        <FilterForm activeFilter={activeFilter} filters={filters} />
       )}
       <ClassCards activeLevels={activeLevels} slugExtension={slugExtension} />
     </div>

--- a/src/components/ClassPanel.scss
+++ b/src/components/ClassPanel.scss
@@ -9,6 +9,10 @@
   @media (min-width: 768px) {
     grid-template-columns: 240px 1fr;
     grid-gap: 1rem;
+
+    &__title {
+      grid-column-end: span 2;
+    }
   }
 
   // Large devices (desktops, 992px and up)

--- a/src/components/ClassPanel.scss
+++ b/src/components/ClassPanel.scss
@@ -1,0 +1,19 @@
+.ClassPanel {
+  max-width: 1170px;
+  margin: auto auto 4rem;
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr;
+
+  // Medium devices (tablets, 768px and up)
+  @media (min-width: 768px) {
+    grid-template-columns: 240px 1fr;
+    grid-gap: 1rem;
+  }
+
+  // Large devices (desktops, 992px and up)
+  @media (min-width: 992px) {
+    grid-template-columns: 320px 1fr;
+    grid-gap: 2rem;
+  }
+}

--- a/src/components/FilterForm.js
+++ b/src/components/FilterForm.js
@@ -36,11 +36,17 @@ const FilterCheckboxGroup = ({ filter }) => {
 };
 
 // based off of formik's AutoSave example
+const DELAY = 200;
 const SubmitOnChange = () => {
   const { submitForm, values } = useFormikContext();
+  const firstMountedAt = React.useRef(false); // skips save on initial load
 
   React.useEffect(() => {
-    submitForm();
+    if (firstMountedAt.current && firstMountedAt.current < Date.now() - DELAY) {
+      submitForm();
+    } else if (!firstMountedAt.current) {
+      firstMountedAt.current = Date.now();
+    }
   }, [submitForm, values]);
 
   return null;

--- a/src/components/FilterForm.js
+++ b/src/components/FilterForm.js
@@ -37,11 +37,11 @@ const FilterCheckboxGroup = ({ filter }) => {
 
 // based off of formik's AutoSave example
 const SubmitOnChange = () => {
-  const formik = useFormikContext();
+  const { submitForm, values } = useFormikContext();
 
   React.useEffect(() => {
-    formik.submitForm();
-  }, [formik.submitForm, formik.values]);
+    submitForm();
+  }, [submitForm, values]);
 
   return null;
 };

--- a/src/components/Footer.scss
+++ b/src/components/Footer.scss
@@ -1,6 +1,5 @@
 .Footer {
   padding: 3rem 0;
-  margin-top: 3rem;
   background-color: var(--background);
   border-top: .5rem solid var(--backgroundAlt);
 

--- a/src/components/Footer.scss
+++ b/src/components/Footer.scss
@@ -1,6 +1,8 @@
 .Footer {
   padding: 3rem 0;
-  background-color: #fbf6ee;
+  margin-top: 3rem;
+  background-color: var(--background);
+  border-top: .5rem solid var(--backgroundAlt);
 
   &__logo {
     display: block;

--- a/src/components/PageBuilder.js
+++ b/src/components/PageBuilder.js
@@ -48,11 +48,12 @@ ComponentSelector.propTypes = {
 const PageBuilder = ({ data = [] }) => {
   return (
     <div className="page-builder">
-      {data.map(component => {
+      {data.map((component, componentIndex) => {
         return (
           <div
             className="container"
             style={{ backgroundColor: component.bgColor }}
+            key={componentIndex}
           >
             <ComponentSelector data={component} />
           </div>

--- a/src/components/all.scss
+++ b/src/components/all.scss
@@ -170,8 +170,11 @@ figure {
 }
 hr {
   box-sizing: content-box;
-  height: 0.0625rem;
+  height: 2px;
   background: var(--hr);
+  margin: 0 0 calc(1.75rem - 2px);
+  padding: 0;
+  border: none;
 }
 button,
 input,

--- a/src/pages/classes.js
+++ b/src/pages/classes.js
@@ -1,101 +1,13 @@
 import * as React from "react";
 import { Helmet } from "react-helmet";
 import { graphql } from "gatsby";
-import { isMobile } from "../utils/helpers";
-
-import { useFilters } from "../hooks";
-import FilterForm from "../components/FilterForm";
 
 import Layout from "../components/Layout";
 
+import ClassPanel from "../components/ClassPanel";
 import CtaContact from "../components/CtaContact";
-import ClassCards from "../components/ClassCards";
 
 import "./classes.scss";
-
-const seasonScore = {
-  Spring: 1,
-  Summer: 2,
-  Fall: 3
-}
-
-const sortSemester = (a, b) => {
-  const [aSeason, aYear] = a.value.split(" ");
-  const [bSeason, bYear] = b.value.split(" ");
-
-  if (aYear > bYear) return 1;
-  if (aYear < bYear) return -1;
-
-  const aSeasonScore = seasonScore[aSeason] || 4;
-  const bSeasonScore = seasonScore[bSeason] || 4;
-
-  if (aSeasonScore > bSeasonScore) return 1;
-  if (aSeasonScore < bSeasonScore) return -1;
-
-  return 0
-
-}
-
-const filterTemplate = [
-  {
-    label: "SEMESTER",
-    filterKey: "semesters",
-    type: "checkbox",
-    optionValueKeys: ["extras", "semesters"],
-    sort: sortSemester
-  },
-  {
-    label: "EXPERIENCE",
-    filterKey: "experiences",
-    type: "checkbox",
-    optionValueKeys: ["details", "experience"],
-  },
-  {
-    label: "GENDER",
-    filterKey: "genders",
-    type: "checkbox",
-    optionValueKeys: ["details", "gender"],
-  },
-  {
-    label: "SKILLS",
-    filterKey: "skills",
-    type: "checkbox",
-    optionValueKeys: ["details", "skills"],
-  },
-  {
-    label: "LOOKING FOR",
-    filterKey: "sellingPoints",
-    type: "checkbox",
-    optionValueKeys: ["details", "sellingPoints"],
-  },
-];
-
-const ClassPanel = ({ experienceLevels }) => {
-  const [filters, activeFilter, activeLevels] = useFilters(
-    filterTemplate,
-    experienceLevels
-  );
-
-  return (
-    <div className="ClassPanel">
-      {!!isMobile() ? (
-        <details className="custom-details-tag">
-          <summary>Filter By </summary>
-          <FilterForm
-            activeFilter={activeFilter}
-            filters={filters}
-          />
-        </details>
-      ) : (
-        <FilterForm
-          activeFilter={activeFilter}
-          filters={filters}
-        />
-      )}
-      <ClassCards activeLevels={activeLevels} />
-    </div>
-  );
-};
 
 const ClassesPage = ({ data }) => {
   const experienceLevels = data.experienceLevelQuery.experienceLevels?.map(

--- a/src/pages/classes.scss
+++ b/src/pages/classes.scss
@@ -25,23 +25,3 @@
     }
   }
 }
-
-.ClassPanel {
-  max-width: 1170px;
-  margin: auto auto 4rem;
-  width: 100%;
-  display: grid;
-  grid-template-columns: 1fr;
-
-  // Medium devices (tablets, 768px and up)
-  @media (min-width: 768px) {
-    grid-template-columns: 240px 1fr;
-    grid-gap: 1rem;
-  }
-
-  // Large devices (desktops, 992px and up)
-  @media (min-width: 992px) {
-    grid-template-columns: 320px 1fr;
-    grid-gap: 2rem;
-  }
-}

--- a/src/templates/location.js
+++ b/src/templates/location.js
@@ -1,9 +1,10 @@
 import * as React from "react";
 import { Helmet } from "react-helmet";
-import { graphql, Link } from "gatsby";
+import { graphql } from "gatsby";
 
-import ClassCards from "../components/ClassCards";
 import Layout from "../components/Layout";
+
+import ClassPanel from "../components/ClassPanel";
 import MapDisplay from "../components/MapDisplay";
 
 const LocationPage = ({ data }) => {
@@ -64,18 +65,7 @@ const LocationPage = ({ data }) => {
             </>
           )}
         </div>
-        <section>
-          <h2>Current Offerings</h2>
-            <ClassCards
-              activeLevels={activeLevels}
-              slugExtension={locationQueryString}
-            />
-        </section>
-        <hr />
-        <details>
-          <summary>Show Data Props</summary>
-          <pre>{JSON.stringify(data, null, 2)}</pre>
-        </details>
+        <ClassPanel experienceLevels={activeLevels} slugExtension={locationQueryString} />
       </div>
     </Layout>
   );

--- a/src/templates/location.js
+++ b/src/templates/location.js
@@ -44,7 +44,7 @@ const LocationPage = ({ data }) => {
         <meta name="description" content={description} />
       </Helmet>
       <div className="Location">
-        <div className="Location__hero">
+        <div className={`Location__hero${activeLocation.isOnline ? " Location__hero--online": ""}`}>
           {!activeLocation.isOnline && (
             <MapDisplay
               addressCoords={[

--- a/src/templates/location.js
+++ b/src/templates/location.js
@@ -1,0 +1,7 @@
+import * as React from "react";
+
+const LocationPage = () => {
+  return <h1>LocationPage</h1>
+}
+
+export default LocationPage;

--- a/src/templates/location.js
+++ b/src/templates/location.js
@@ -1,7 +1,129 @@
 import * as React from "react";
+import { Helmet } from "react-helmet";
+import { graphql, Link } from "gatsby";
 
-const LocationPage = () => {
-  return <h1>LocationPage</h1>
-}
+import ClassCards from "../components/ClassCards";
+import Layout from "../components/Layout";
+import MapDisplay from "../components/MapDisplay";
+
+const LocationPage = ({ data }) => {
+  const activeLocation = data.classLocation;
+
+  const description = activeLocation.isOnline
+    ? `Connect to curriculum from anywhere with our suite of virtual courses!`
+    : `Our ${activeLocation.name} location is located at ${data.addressString}.`;
+
+  // mimic transformation in LocationsPanel
+  const experienceLevels = data.experienceLevelQuery.experienceLevels?.map(
+    (levelNode) => {
+      return {
+        ...levelNode.frontmatter,
+        slug: levelNode.fields.slug,
+      };
+    }
+  );
+  const activeLevels = experienceLevels.filter((l) => {
+    const levelCategoryIds = l.categoryIds.map((str) => Number(str)); // Netlify CMS saves strings
+    return activeLocation.categoryIds.some((catId) =>
+      levelCategoryIds.includes(catId)
+    );
+  });
+
+  const locationQueryString = !!activeLocation.courseOfferingsEndpoint
+    ? new URL(activeLocation.courseOfferingsEndpoint).search
+    : "";
+
+  return (
+    <Layout>
+      <Helmet titleTemplate="%s | Locations">
+        <title>{activeLocation.name}</title>
+        <meta
+          name="description"
+          content={`${description}.`}
+        />
+      </Helmet>
+      <div className="Location">
+        <div className="Location__hero">
+          <h1>{activeLocation.name}</h1>
+          {activeLocation.isOnline ? (
+            <>
+              <p>
+                Connect to curriculum from anywhere with our suite of virtual
+                courses!
+              </p>
+            </>
+          ) : (
+            <>
+              <p>{activeLocation.addressString}</p>
+              <MapDisplay
+                addressCoords={[
+                  activeLocation.latitude,
+                  activeLocation.longitude,
+                ]}
+              />
+            </>
+          )}
+        </div>
+        <section>
+          <h2>Current Offerings</h2>
+            <ClassCards
+              activeLevels={activeLevels}
+              slugExtension={locationQueryString}
+            />
+        </section>
+        <hr />
+        <details>
+          <summary>Show Data Props</summary>
+          <pre>{JSON.stringify(data, null, 2)}</pre>
+        </details>
+      </div>
+    </Layout>
+  );
+};
 
 export default LocationPage;
+
+export const pageQuery = graphql`
+  query LocationsByCode($code: String!) {
+    classLocation(code: { eq: $code }) {
+      classLocationId
+      code
+      name
+      isOnline
+      latitude
+      longitude
+      addressString
+      categoryIds
+      courseOfferingsEndpoint
+    }
+    experienceLevelQuery: allMarkdownRemark(
+      filter: { frontmatter: { templateKey: { eq: "experience-levels" } } }
+    ) {
+      experienceLevels: nodes {
+        frontmatter {
+          heading
+          title
+          categoryIds
+          details {
+            age
+            gender
+            byline
+            skills
+          }
+          thumbnail {
+            childImageSharp {
+              fluid(maxWidth: 480, quality: 80) {
+                ...GatsbyImageSharpFluid
+              }
+            }
+            extension
+            publicURL
+          }
+        }
+        fields {
+          slug
+        }
+      }
+    }
+  }
+`;

--- a/src/templates/location.js
+++ b/src/templates/location.js
@@ -19,10 +19,10 @@ const LocationPage = ({ data }) => {
 
   // mimic transformation in LocationsPanel
   const experienceLevels = data.experienceLevelQuery.experienceLevels?.map(
-    (levelNode) => {
+    levelNode => {
       return {
-        ...levelNode.frontmatter,
-        slug: levelNode.fields.slug,
+        ...levelNode.frontmatter, // most MD file things
+        ...levelNode.fields // slug, extras
       };
     }
   );
@@ -138,6 +138,9 @@ export const pageQuery = graphql`
         }
         fields {
           slug
+          extras {
+            semesters
+          }
         }
       }
     }

--- a/src/templates/location.js
+++ b/src/templates/location.js
@@ -125,6 +125,8 @@ export const pageQuery = graphql`
             gender
             byline
             skills
+            experience
+            sellingPoints
           }
           thumbnail {
             childImageSharp {

--- a/src/templates/location.js
+++ b/src/templates/location.js
@@ -6,6 +6,9 @@ import Layout from "../components/Layout";
 
 import ClassPanel from "../components/ClassPanel";
 import MapDisplay from "../components/MapDisplay";
+import CtaContact from "../components/CtaContact";
+
+import "./styles/location.scss";
 
 const LocationPage = ({ data }) => {
   const activeLocation = data.classLocation;
@@ -38,35 +41,56 @@ const LocationPage = ({ data }) => {
     <Layout>
       <Helmet titleTemplate="%s | Locations">
         <title>{activeLocation.name}</title>
-        <meta
-          name="description"
-          content={`${description}.`}
-        />
+        <meta name="description" content={description} />
       </Helmet>
       <div className="Location">
         <div className="Location__hero">
-          <h1>{activeLocation.name}</h1>
-          {activeLocation.isOnline ? (
-            <>
+          {!activeLocation.isOnline && (
+            <MapDisplay
+              addressCoords={[
+                activeLocation.latitude,
+                activeLocation.longitude,
+              ]}
+            />
+          )}
+          <div className="Location__hero__text">
+            <h1 className="title">{activeLocation.name}</h1>
+            {activeLocation.isOnline ? (
               <p>
                 Connect to curriculum from anywhere with our suite of virtual
                 courses!
               </p>
-            </>
-          ) : (
-            <>
-              <p>{activeLocation.addressString}</p>
-              <MapDisplay
-                addressCoords={[
-                  activeLocation.latitude,
-                  activeLocation.longitude,
-                ]}
-              />
-            </>
-          )}
+            ) : (
+              <>
+                <p>
+                  <strong>Address:</strong>{" "}
+                  <a
+                    href={activeLocation.addressLink}
+                    target="_blank"
+                    rel="noreferrer"
+                    style={{ color: "currentColor"}}
+                  >
+                    {activeLocation.addressString}
+                  </a>
+                </p>
+                {!!activeLocation.addressNotes && (
+                  <div
+                    dangerouslySetInnerHTML={{
+                      __html: activeLocation.addressNotes,
+                    }}
+                  />
+                )}
+              </>
+            )}
+          </div>
         </div>
-        <ClassPanel experienceLevels={activeLevels} slugExtension={locationQueryString} />
+        <ClassPanel
+          title={`${activeLocation.name} Catalog`}
+          experienceLevels={activeLevels}
+          slugExtension={locationQueryString}
+        />
       </div>
+      <CtaContact />
     </Layout>
   );
 };
@@ -83,6 +107,8 @@ export const pageQuery = graphql`
       latitude
       longitude
       addressString
+      addressNotes
+      addressLink
       categoryIds
       courseOfferingsEndpoint
     }

--- a/src/templates/locations.js
+++ b/src/templates/locations.js
@@ -128,8 +128,8 @@ const LocationsPage = ({ data }) => {
     <Layout>
       <LocationsPageTemplate
         helmet={
-          <Helmet titleTemplate="The Coding Space Signup">
-            <title>{`${title}`}</title>
+          <Helmet>
+            <title>{title}</title>
             <meta name="description" content={`${seoDescription}`} />
           </Helmet>
         }

--- a/src/templates/locations.js
+++ b/src/templates/locations.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Helmet } from "react-helmet";
-import { graphql } from "gatsby";
+import { graphql, Link } from "gatsby";
 
 import ClassCards from "../components/ClassCards";
 import Layout from "../components/Layout";
@@ -60,6 +60,7 @@ const LocationsPanel = ({ locations, experienceLevels }) => {
       <div className="LocationsPanel__main">
         <div className="LocationsPanel__main__details">
           <h3>{activeLocation.name}</h3>
+          <Link to={`/locations/${activeLocation.code}`}>View Full Details</Link>
           {activeLocation.isOnline ? (
             <>
               <p>
@@ -212,6 +213,7 @@ export const pageQuery = graphql`
     allClassLocation {
       locations: nodes {
         classLocationId
+        code
         name
         isOnline
         latitude

--- a/src/templates/styles/location.scss
+++ b/src/templates/styles/location.scss
@@ -23,6 +23,11 @@
       grid-gap: 2rem;
       align-items: center;
 
+      &--online {
+        padding: 2rem 1rem;
+        grid-template-columns: 1fr;
+      }
+
       .leaflet-container {
         box-sizing: border-box;
         min-height: 260px;

--- a/src/templates/styles/location.scss
+++ b/src/templates/styles/location.scss
@@ -1,0 +1,33 @@
+.Location {
+  padding: 1rem;
+
+  &__hero {
+    max-width: 1170px;
+    margin: auto auto 1rem;
+    width: 100%;
+    color: var(--text-primary);
+    display: grid;
+    grid-template-columns: 1fr;
+
+    .leaflet-container {
+      box-sizing: border-box;
+      min-height: 260px;
+      width: 100%;
+    }
+  }
+
+  // Medium + large devices (660px and up)
+  @media (min-width: 660px) {
+    &__hero {
+      grid-template-columns: 320px 1fr;
+      grid-gap: 2rem;
+      align-items: center;
+
+      .leaflet-container {
+        box-sizing: border-box;
+        min-height: 260px;
+        width: 100%;
+      }
+    }
+  }
+}

--- a/src/templates/styles/locations.scss
+++ b/src/templates/styles/locations.scss
@@ -91,6 +91,9 @@
       h3 {
         font-size: 1.5rem;
       }
+      a, a:visited {
+        color: inherit;
+      }
       .leaflet-container {
         height: 100px;
         width: 100%;


### PR DESCRIPTION
I wanted to update the LocationPanel to be a "simple" hash router 

I then learned that the version of Gatsby we're on uses `@reach/router` v1 which doesn't have a super simple analog to what I was looking for

As such I bit the bullet and made a simple, dedicated location page. Over time we'll almost certainly want to have the page builder touch this.

While clicking around the site I also did some tidying up