### PR TITLE
Prepare for Storybook static site.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ public/
 static/admin/*.bundle.*
 .DS_Store
 yarn-error.log
+# directory for static storybook site, compiled in netlify
+storybook-static/


### PR DESCRIPTION
Add static storybook site to git ignore as those changes shouldn't be tracked in this project. I'll point Netlify to this directory, and have it run `yarn run build-storybook` to compile a static site for marketing to use!