### PR TITLE
Attempt bug fix for disappearing description.

### DIFF
--- a/src/templates/template_exports/experience-levels-template.js
+++ b/src/templates/template_exports/experience-levels-template.js
@@ -29,7 +29,10 @@ export const ExperienceLevelsTemplate = ({
             <span className="course-hero__text__byline">{byline}</span>
             {title}
           </h1>
-          <p dangerouslySetInnerHTML={htmlContent} />
+          <div
+            className="course-hero__text__content"
+            dangerouslySetInnerHTML={htmlContent}
+          />
         </div>
         <div className="course-hero__card">
           <header className="course-hero__card__header">


### PR DESCRIPTION
Inserted markdown to html disappearing in production after fetching
results and reloading. Testing to see if it has something to do with
improper nesting of \<p> tags.