### PR TITLE
Add PageBuilder to blog posts.

### DIFF
--- a/src/cms/preview-templates/BlogPostPreview.js
+++ b/src/cms/preview-templates/BlogPostPreview.js
@@ -8,6 +8,8 @@ const BlogPostPreview = ({ entry, widgetFor }) => {
 
   const tags = entry.getIn(["data", "tags"]);
   const featuredImage = entry.getIn(["data", "featuredImage"]).toJS();
+  const entryPageBuilder = entry.getIn(["data", "pageBuilder"]);
+  const pageBuilder = entryPageBuilder ? entryPageBuilder.toJS() : [];
 
   return (
     <BlogPostTemplate
@@ -16,6 +18,7 @@ const BlogPostPreview = ({ entry, widgetFor }) => {
       date={entry.getIn(["data", "date"]).toString()}
       description={entry.getIn(["data", "description"])}
       featuredImage={featuredImage}
+      pageBuilder={pageBuilder}
       tags={tags && tags.toJS()}
       title={entry.getIn(["data", "title"])}
       titleColor={entry.getIn(["data", "titleColor"])}

--- a/src/components/BuilderComponents/styles/SideBySide.scss
+++ b/src/components/BuilderComponents/styles/SideBySide.scss
@@ -5,10 +5,14 @@
 
   &__left-component {
     flex: 1 1 auto;
+    display: grid;
+    align-items: center;
   }
 
   &__right-component {
     flex: 1 1 auto;
+    display: grid;
+    align-items: center;
   }
   // Medium devices (large tablets, computers and up)
   @media (min-width: 992px) {

--- a/src/pages/blog/2021-11-16-what-inspires-our-coders-to-give-back.md
+++ b/src/pages/blog/2021-11-16-what-inspires-our-coders-to-give-back.md
@@ -26,7 +26,7 @@ pageBuilder:
         title: Test
     rightComponent:
       - type: boxWithLogo
-        bgColor: "#ffffff"
+        bgColor: "#264548"
         fgColor: "#9de2dd"
         textColor: "#264548"
         heading: Testing Interactive content in blog
@@ -38,6 +38,24 @@ pageBuilder:
           projects, and presentations. But what inspires them to give back and
           why are they excited to help? We asked them, and here's how they
           answered:"
+  - type: sideBySide
+    bgColor: "#ffffff"
+    leftComponent:
+      - type: iframe
+        bgColor: "#ffffff"
+        content: https://scratch.mit.edu/projects/510001177/embed
+        ratio: ratio16x9
+        title: testing
+    rightComponent:
+      - type: textOnly
+        textAlign: center
+        bgColor: "#faf6ee"
+        textColor: "#264548"
+        mdContent: >-
+          ### Testing Interactive content in blog
+
+
+          With Code 4 Change: Kids Teaching Kids rounding the halfway mark, we wanted to take a moment to check in with our coders. Participants of all ages and skill levels are hard at work coding their Kids Teaching Kids projects, which are aimed at helping early elementary learners understand important academic concepts through engaging games, projects, and presentations. But what inspires them to give back and why are they excited to help? We asked them, and here's how they answered:
 tags:
   - give-back
 ---

--- a/src/pages/blog/2021-11-16-what-inspires-our-coders-to-give-back.md
+++ b/src/pages/blog/2021-11-16-what-inspires-our-coders-to-give-back.md
@@ -17,7 +17,7 @@ featuredImage:
   alt: Girls around a table coding.
 pageBuilder:
   - type: sideBySide
-    bgColor: "#faf6ee"
+    bgColor: "#ffffff"
     leftComponent:
       - type: iframe
         bgColor: "#faf6ee"

--- a/src/pages/blog/2021-11-16-what-inspires-our-coders-to-give-back.md
+++ b/src/pages/blog/2021-11-16-what-inspires-our-coders-to-give-back.md
@@ -26,7 +26,7 @@ pageBuilder:
         title: Test
     rightComponent:
       - type: boxWithLogo
-        bgColor: "#faf6ee"
+        bgColor: "#ffffff"
         fgColor: "#9de2dd"
         textColor: "#264548"
         heading: Testing Interactive content in blog

--- a/src/pages/blog/2021-11-16-what-inspires-our-coders-to-give-back.md
+++ b/src/pages/blog/2021-11-16-what-inspires-our-coders-to-give-back.md
@@ -20,7 +20,7 @@ pageBuilder:
     bgColor: "#ffffff"
     leftComponent:
       - type: iframe
-        bgColor: "#faf6ee"
+        bgColor: "#ffffff"
         content: https://scratch.mit.edu/projects/510001177/embed
         ratio: ratio16x9
         title: Test
@@ -49,7 +49,7 @@ pageBuilder:
     rightComponent:
       - type: textOnly
         textAlign: center
-        bgColor: "#faf6ee"
+        bgColor: "#ffffff"
         textColor: "#264548"
         mdContent: >-
           ### Testing Interactive content in blog

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -9,8 +9,16 @@ import { withPrefix } from "gatsby";
 
 const BlogPost = ({ data, location }) => {
   const { markdownRemark: post } = data;
-  const { bgColor, date, description, featuredImage, tags, title, titleColor } =
-    post.frontmatter;
+  const {
+    bgColor,
+    date,
+    description,
+    featuredImage,
+    tags,
+    title,
+    titleColor,
+    pageBuilder,
+  } = post.frontmatter;
   return (
     <Layout>
       <BlogPostTemplate
@@ -29,14 +37,14 @@ const BlogPost = ({ data, location }) => {
             <meta property="og:description" content={`${description}`} />
             <meta
               property="og:image"
-              content={`${withPrefix("/")}${featuredImage.image.childImageSharp.fluid.src}`}
+              content={`${withPrefix("/")}${
+                featuredImage.image.childImageSharp.fluid.src
+              }`}
             />
-            <meta
-              property="og:image:alt"
-              content={featuredImage.alt}
-            />
+            <meta property="og:image:alt" content={featuredImage.alt} />
           </Helmet>
         }
+        pageBuilder={pageBuilder}
         postUrl={location?.href}
         tags={tags}
         title={title}
@@ -76,6 +84,59 @@ export const pageQuery = graphql`
         titleColor
         description
         tags
+        pageBuilder {
+          content
+          heading
+          image {
+            alt
+            image {
+              childImageSharp {
+                fluid(maxWidth: 2048, quality: 100) {
+                  ...GatsbyImageSharpFluid
+                }
+              }
+            }
+          }
+          mdContent
+          mediaPosition
+          type
+          leftComponent {
+            bgColor
+            content
+            fgColor
+            heading
+            mdContent
+            ratio
+            textColor
+            title
+            type
+          }
+          list {
+            content
+            title
+            mdContent
+            fgColor
+            bgColor
+            textColor
+            textAlign
+          }
+          rightComponent {
+            bgColor
+            content
+            fgColor
+            heading
+            mdContent
+            ratio
+            textColor
+            title
+            type
+          }
+          textAlign
+          textColor
+          title
+          fgColor
+          bgColor
+        }
       }
     }
   }

--- a/src/templates/template_exports/blog-post-template.js
+++ b/src/templates/template_exports/blog-post-template.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { Link } from "gatsby";
 import { kebabCase } from "lodash";
 import Content from "../../components/Content";
+import PageBuilder from "../../components/PageBuilder";
 import PreviewCompatibleImage from "../../components/PreviewCompatibleImage";
 import facebook from "../../img/social/facebook.svg";
 
@@ -17,6 +18,7 @@ export const BlogPostTemplate = ({
   title,
   titleColor,
   helmet,
+  pageBuilder,
   postUrl,
 }) => {
   const PostContent = contentComponent || Content;
@@ -28,6 +30,9 @@ export const BlogPostTemplate = ({
       window.location.href
     )}`;
   }
+
+  const data = pageBuilder ?? [];
+
   return (
     <React.Fragment>
       {helmet || ""}
@@ -54,6 +59,7 @@ export const BlogPostTemplate = ({
           </div>
           <div className="blog-post__content">
             <PostContent content={content} />
+            <PageBuilder data={data} />
           </div>
           <hr />
           <div className="blog-post__footer">

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -615,6 +615,7 @@ collections:
             ],
         }
       - { label: "Body", name: "body", widget: "markdown" }
+      - *page_builder
       - { label: "Tags", name: "tags", widget: "list" }
   - name: "custom"
     label: "Customizable Pages"

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: git-gateway
-  branch: main
+  branch: interactive-blog
   commit_messages:
     create: "Create {{collection}} “{{slug}}”"
     update: "Update {{collection}} “{{slug}}”"

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: git-gateway
-  branch: interactive-blog
+  branch: main
   commit_messages:
     create: "Create {{collection}} “{{slug}}”"
     update: "Update {{collection}} “{{slug}}”"


### PR DESCRIPTION
This gives additional flexibility when creating blog posts, especially
important for demonstrating student projects in SideBySide (items).

This functionality is limited to the bottom of the blog post body content,
but should be enough for the typical use case of listing student projects.

This initial commit will allow for testing in the preview. 