### PR TITLE
IOS date picker fix for 0 height/width bug.

### DIFF
--- a/src/components/sign_up/styles/sign-up.scss
+++ b/src/components/sign_up/styles/sign-up.scss
@@ -88,6 +88,9 @@
         color: var(--dark);
         font-size: 1rem;
         padding: 0 10px;
+        // iOS date picker bug has no height and width
+        min-height: 22px;
+        min-width: 204px;
       }
 
       input:focus,


### PR DESCRIPTION
Only on mobile IOS devices, the default date picker is rendering
with 0 height and width, causing the field to look flat with the
perceived impression that it is unclickable. This forces a minimum
height and width on the fields so that it looks clickable.

Once the user clicks, the field works as expected.

Bug
![Screen Shot 2022-01-07 at 10 55 11 AM](https://user-images.githubusercontent.com/30125327/148586145-91514487-e789-4167-b653-e30bf1ce3877.png)

