### PR TITLE
Use titles as slugs for experience levels.

### DIFF
--- a/src/components/ClassCards.js
+++ b/src/components/ClassCards.js
@@ -3,7 +3,7 @@ import { Link } from "gatsby";
 
 import PreviewCompatibleImage from "./PreviewCompatibleImage";
 
-import "./ClassCards.scss"
+import "./ClassCards.scss";
 
 const ClassCards = ({ activeLevels, slugExtension = "" }) => {
   if (!activeLevels.length) {
@@ -24,12 +24,9 @@ const ClassCards = ({ activeLevels, slugExtension = "" }) => {
         ) => {
           return (
             <li className="class-card-list__item" key={levelIndex}>
-              <Link
-                className="class-card"
-                to={`${slug}${slugExtension}`}
-              >
+              <Link className="class-card" to={`${slug}${slugExtension}`}>
                 <div className="class-card__top">
-                  <p className="gender">{gender}</p>
+                  <p className="gender">{gender.join(", ")}</p>
                   <p className="age">{age}</p>
                 </div>
                 <h4 className="class-card__title">{title}</h4>

--- a/src/pages/classes.js
+++ b/src/pages/classes.js
@@ -99,7 +99,7 @@ export const pageQuery = graphql`
           }
           thumbnail {
             childImageSharp {
-              gatsbyImageData(height: 200, quality: 80, layout: FIXED)
+              gatsbyImageData(height: 200, quality: 80, layout: CONSTRAINED)
             }
             extension
             publicURL

--- a/src/pages/experience-levels/advanced-code.md
+++ b/src/pages/experience-levels/advanced-code.md
@@ -11,7 +11,8 @@ courseOfferingEndpoint: /feeds/coding_space/classes?class_category_ids[]=45
 thumbnail: /img/white-board.jpg
 details:
   age: Ages 8+
-  gender: Co-ed.
+  gender:
+    - Co-ed.
   byline: Advanced Scratch, HTML, CSS, and JavaScript.
   experience: JavaScript or Other Text-Based Language
   skills:

--- a/src/pages/experience-levels/advanced-girlcode.md
+++ b/src/pages/experience-levels/advanced-girlcode.md
@@ -10,7 +10,8 @@ courseOfferingEndpoint: /feeds/coding_space/classes?class_category_ids[]=48
 thumbnail: /img/coder.jpg
 details:
   age: Ages 8+
-  gender: GirlCode
+  gender:
+    - GirlCode
   byline: Scratch through JavaScript
   experience: Some Experience Required
   skills:

--- a/src/pages/experience-levels/beginner-code.md
+++ b/src/pages/experience-levels/beginner-code.md
@@ -11,7 +11,8 @@ courseOfferingEndpoint: /feeds/coding_space/classes?class_category_ids[]=46
 thumbnail: /img/sisters-doing-their-homework-orig.jpg
 details:
   age: Ages 8+
-  gender: Co-ed.
+  gender:
+    - Co-ed.
   byline: Intro to Scratch
   experience: First-Time or Beginner Coders
   skills:

--- a/src/pages/experience-levels/beginner-girlcode.md
+++ b/src/pages/experience-levels/beginner-girlcode.md
@@ -10,7 +10,8 @@ courseOfferingEndpoint: /feeds/coding_space/classes?class_category_ids[]=47
 thumbnail: /img/girl-code-group.jpg
 details:
   age: Ages 8+
-  gender: GirlCode
+  gender:
+    - GirlCode
   byline: Intro to Scratch
   experience: First-Time or Beginner Coders
   skills:

--- a/src/pages/experience-levels/camp-coding-space.md
+++ b/src/pages/experience-levels/camp-coding-space.md
@@ -8,6 +8,7 @@ seo_description: Our summer camp is back and better than ever! Held from June to
 categoryIds:
   - 95
 courseOfferingEndpoint: /feeds/coding_space/classes?class_category_ids[]=95
+display: true
 thumbnail: /img/kids-around-a-computer.jpg
 details:
   age: Ages 8+

--- a/src/pages/experience-levels/camp-coding-space.md
+++ b/src/pages/experience-levels/camp-coding-space.md
@@ -12,7 +12,9 @@ display: true
 thumbnail: /img/kids-around-a-computer.jpg
 details:
   age: Ages 8+
-  gender: Co-ed., GirlCode
+  gender:
+    - Co-ed.
+    - GirlCode
   byline: Monday through Friday, 1 & 2 Week Options Available
   experience: First-Time Through Advanced
   skills:

--- a/src/pages/experience-levels/half-day-camp.md
+++ b/src/pages/experience-levels/half-day-camp.md
@@ -11,7 +11,7 @@ courseOfferingEndpoint: /feeds/coding_space/classes?class_category_ids[]=95
 thumbnail: /img/kids-around-a-computer.jpg
 details:
   age: Ages 8+
-  gender: Co-ed.
+  gender: Co-ed., GirlCode
   byline: Monday through Friday, 1 & 2 Week Options Available
   experience: First-Time Through Advanced
   skills:

--- a/src/pages/experience-levels/high-school-code.md
+++ b/src/pages/experience-levels/high-school-code.md
@@ -11,7 +11,8 @@ courseOfferingEndpoint: /feeds/coding_space/classes?class_category_ids[]=49
 thumbnail: /img/teenage-boy-on-computer-1.jpg
 details:
   age: Ages 14-17
-  gender: Co-ed.
+  gender:
+    - Co-ed.
   byline: Prepare to blast off.
   experience: First-Time Through Advanced
   skills:

--- a/src/pages/experience-levels/intermediate-code.md
+++ b/src/pages/experience-levels/intermediate-code.md
@@ -10,7 +10,8 @@ courseOfferingEndpoint: /feeds/coding_space/classes?class_category_ids[]=104
 thumbnail: /img/collaborative-group-space.jpg
 details:
   age: Ages 8+
-  gender: Co-ed.
+  gender:
+    - Co-ed.
   byline: Scratch through Javascript
   experience: Some Experience Required
   skills:

--- a/src/pages/experience-levels/intermediate-girlcode.md
+++ b/src/pages/experience-levels/intermediate-girlcode.md
@@ -10,7 +10,8 @@ courseOfferingEndpoint: /feeds/coding_space/classes?class_category_ids[]=105
 thumbnail: /img/girlcode-three-around-computer.jpg
 details:
   age: Ages 8+
-  gender: GirlCode
+  gender:
+    - GirlCode
   byline: Scratch through Javascript
   experience: Some Experience Required
   skills:

--- a/src/pages/experience-levels/young-beginner-code.md
+++ b/src/pages/experience-levels/young-beginner-code.md
@@ -11,7 +11,8 @@ courseOfferingEndpoint: /feeds/coding_space/classes?class_category_ids[]=50
 thumbnail: /img/two-girls-coding-scratch.png
 details:
   age: Ages 6-8
-  gender: Co-ed.
+  gender:
+    - Co-ed.
   byline: Intro to Coding
   experience: Young & First-Time Coders
   skills:

--- a/src/templates/template_exports/experience-levels-template.js
+++ b/src/templates/template_exports/experience-levels-template.js
@@ -9,15 +9,8 @@ export const ExperienceLevelsTemplate = ({
   title,
   helmet,
 }) => {
-  const {
-    age,
-    gender,
-    byline,
-    mdContent,
-    experience,
-    skills,
-    sellingPoints,
-  } = details;
+  const { age, gender, byline, mdContent, experience, skills, sellingPoints } =
+    details;
   const htmlContent = createHtml(mdContent);
 
   return (
@@ -36,7 +29,7 @@ export const ExperienceLevelsTemplate = ({
         </div>
         <div className="course-hero__card">
           <header className="course-hero__card__header">
-            <span>{gender}</span>
+            <span>{gender.join(", ")}</span>
             <span>{age}</span>
           </header>
           <p className="course-hero__card__detail-title">Includes</p>

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -744,7 +744,9 @@ collections:
                 label: "Gender",
                 name: "gender",
                 default: "GirlCode",
-                widget: "string",
+                widget: "select",
+                multiple: true,
+                options: ["GirlCode", "Co-ed."],
               },
               {
                 label: "Byline",

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: git-gateway
-  branch: summer-camp-fixes
+  branch: main
   commit_messages:
     create: "Create {{collection}} “{{slug}}”"
     update: "Update {{collection}} “{{slug}}”"

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -692,7 +692,7 @@ collections:
     label: "Experience Levels (class categories)"
     folder: "src/pages/experience-levels"
     create: true
-    slug: "{{title}}"
+    slug: "{{slug}}"
     fields:
       - {
           label: "Template Key",
@@ -717,6 +717,15 @@ collections:
           name: "courseOfferingEndpoint",
           hint: "Ask someone on the PP Dashboard team for this!",
           widget: "string",
+        }
+      - {
+          label: "Display in class offerings",
+          name: "display",
+          hint:
+            "Useful for hiding course offerings that aren't offered in a
+            particular semester or for soft archiving",
+          default: true,
+          widget: "boolean",
         }
       - { label: "Featured Image", name: "thumbnail", widget: "image" }
       - {

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: git-gateway
-  branch: main
+  branch: summer-camp-fixes
   commit_messages:
     create: "Create {{collection}} “{{slug}}”"
     update: "Update {{collection}} “{{slug}}”"
@@ -692,7 +692,7 @@ collections:
     label: "Experience Levels (class categories)"
     folder: "src/pages/experience-levels"
     create: true
-    slug: "{{slug}}"
+    slug: "{{title}}"
     fields:
       - {
           label: "Template Key",


### PR DESCRIPTION
Maddy noticed a few issues in the process of updating a camp page. This PR includes fixes

- old slug retained after updating title old /experience-levels/half-day-camp/ --> old /experience-levels/camp-coding-space
- overflowing image on /classes cards
-  Co-Ed. -->  Co-ed or GirlCode for camps