### PR TITLE
Help differentiate components with summaries.

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -115,6 +115,7 @@ boxWithLogo:
     label: "Box with Logo",
     name: "boxWithLogo",
     widget: "object",
+    summary: "{{fields.heading}}",
     fields:
       [
         { label: Heading, name: heading, widget: string },
@@ -288,6 +289,7 @@ text:
     label: "Text",
     name: "textOnly",
     widget: "object",
+    summary: "{{fields.mdContent}}",
     fields:
       [
         { label: Content, name: mdContent, widget: markdown },
@@ -331,6 +333,7 @@ page_builder:
           label: "Accordion",
           name: accordion,
           widget: object,
+          summary: "{{fields.heading}}",
           fields:
             [
               *backgroundColor,
@@ -511,6 +514,7 @@ page_builder:
           label: "Side By Side (header)",
           name: "headerAndMarkDownBlock",
           widget: "object",
+          summary: "{{fields.heading}}",
           fields:
             [
               { label: Heading, name: heading, widget: string },
@@ -532,6 +536,7 @@ page_builder:
           label: "Side By Side (image)",
           name: "textAndImageBlock",
           widget: "object",
+          summary: "{{fields.mdContent}}",
           fields:
             [
               *buttons,
@@ -542,6 +547,7 @@ page_builder:
                 label: Image,
                 name: image,
                 widget: object,
+                summary: "{{fields.alt}}",
                 fields:
                   [
                     {


### PR DESCRIPTION
<img width="543" alt="Screen Shot 2022-02-01 at 17 34 23 PM" src="https://user-images.githubusercontent.com/30125327/152074427-9b98de4f-ac52-49fe-9976-d772be145ae5.png">

Telling text components apart in the CMS was becoming a nightmare, this should help some. Unfortunately can't use the summary for components that have nested listed items.