### PR TITLE
Add intersection observer polyfill.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gatsby-source-filesystem": "^3.14.0",
     "gatsby-transformer-remark": "^4.11.0",
     "gatsby-transformer-sharp": "^4.5.0",
+    "intersection-observer": "^0.12.0",
     "leaflet": "^1.7.1",
     "lodash": "^4.17.15",
     "lodash-webpack-plugin": "^0.11.4",

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Helmet } from "react-helmet";
+import { loadPolyfills } from "../utils/pollyfills";
 import Footer from "../components/Footer/Footer";
 import Navbar from "../components/Navbar";
 import "./all.scss";
@@ -103,6 +104,9 @@ const TemplateWrapper = ({ children }) => {
     },
   ];
   const { title, description } = useSiteMetadata();
+
+  loadPolyfills();
+
   return (
     <div>
       <Helmet>

--- a/src/components/shared/FadeIn.js
+++ b/src/components/shared/FadeIn.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
+require("intersection-observer");
 
 const FadeIn = props => {
   const fadeRef = useRef();

--- a/src/components/shared/FadeIn.js
+++ b/src/components/shared/FadeIn.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useRef } from "react";
-require("intersection-observer");
 
 const FadeIn = props => {
   const fadeRef = useRef();

--- a/src/utils/pollyfills.js
+++ b/src/utils/pollyfills.js
@@ -1,5 +1,7 @@
 export const loadPolyfills = async () => {
-  await loadIntersectionObserver();
+  if (typeof window !== "undefined") {
+    await loadIntersectionObserver();
+  }
 };
 
 const loadIntersectionObserver = () => {

--- a/src/utils/pollyfills.js
+++ b/src/utils/pollyfills.js
@@ -1,0 +1,9 @@
+export const loadPolyfills = async () => {
+  await loadIntersectionObserver();
+};
+
+const loadIntersectionObserver = () => {
+  if (typeof window.IntersectionObserver === "undefined") {
+    require("intersection-observer");
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -10145,6 +10145,11 @@ interpret@^2.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
+intersection-observer@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.12.0.tgz#6c84628f67ce8698e5f9ccf857d97718745837aa"
+  integrity sha512-2Vkz8z46Dv401zTWudDGwO7KiGHNDkMv417T5ItcNYfmvHR/1qCTVBO9vwH8zZmQ0WkA/1ARwpysR9bsnop4NQ==
+
 invariant@^2.0.0, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"


### PR DESCRIPTION
Every once in a while we're getting errors related to intersection observers in our FadeIn component. This has only impacted a few users who try to access the site on an unsupported mobile device.

@danielpowell4 It can't be this simple can it? I'm also unsure how to test it because I don't know where to find Internet Explorer nowadays