### PR TITLE
Remove M-F if camp is less than 5 days.

### DIFF
--- a/src/components/CourseOfferings.js
+++ b/src/components/CourseOfferings.js
@@ -50,7 +50,9 @@ const CourseOffering = ({
       </div>
       <div className="overview">
         <h3 className="overview__name">{classTypeName}</h3>
-        {!!isCamp && <h4 className="overview__weekdays">Monday - Friday</h4>}
+        {!!isCamp && sessionCount > 4 && (
+          <h4 className="overview__weekdays">Monday - Friday</h4>
+        )}
         <h4 className="overview__time">{scheduledTimeRange}</h4>
         <h4 className="overview__dates">{dateRange}</h4>
       </div>

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -3,7 +3,6 @@ import { Link } from "gatsby";
 import Layout from "../components/Layout";
 import "./404.scss";
 import rocket from "../img/rocket.png";
-import HoneyBadger from "../utils/honeybadger";
 
 const NotFoundPage = () => {
   const starContainer = createRef();


### PR DESCRIPTION
We don't pass back the days of the week for camps, so we can't know what the exact range is, but in the event that it is shorter (as for July 4th), we'll omit that part to avoid confusion.

![Screen Shot 2023-03-29 at 14 08 15 PM](https://user-images.githubusercontent.com/30125327/228656463-1989d4cb-e229-4eb8-ad61-fcf8bd6241a8.png)
